### PR TITLE
Fix wrong error reported when the value is smaller than the maximum.

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -361,7 +361,7 @@ class Schema extends JsonSchema implements MetaHolder, SchemaContract
             } else {
                 if ($data > $this->maximum) {
                     $this->fail(new NumericException(
-                        'Value less than ' . $this->minimum . ' expected, ' . $data . ' received',
+                        'Value less than ' . $this->maximum . ' expected, ' . $data . ' received',
                         NumericException::MAXIMUM), $path);
                 }
             }


### PR DESCRIPTION
Can be tested with the following:

*Schema*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "$id": "http://json-schema.org/draft-07/schema#",
  "description": "Representation of the core response to the front end",
  "type": "object",
  "required": ["testProperty"],
  "properties": {
    "testProperty": {
        "type": "integer",
        "minimum": 50,
        "maximum: 60
    }
  }
}


*JSON*
{
    "testProperty": 60
}